### PR TITLE
feat: Add participant count retrieval and enhance activity sorting in views

### DIFF
--- a/ParqueInfantil/api/AppServices/ActivityService.py
+++ b/ParqueInfantil/api/AppServices/ActivityService.py
@@ -50,3 +50,6 @@ class ActivityService(GenericService, IActivityService):
 
     def get_most_participated_activities(self):
         return self.activity_repository.get_most_participated_activities()
+    
+    def get_cant_participantes(self,actividad_id):
+        return self.activity_repository.get_cant_participantes(actividad_id)

--- a/ParqueInfantil/api/AppServices/ReservationService.py
+++ b/ParqueInfantil/api/AppServices/ReservationService.py
@@ -12,6 +12,8 @@ from api.InfrastructurePersistence.ActivityRepository import ActivityRepository
 from .ScheduledActService import ScheduledActService
 from .ActivityService import ActivityService
 from django.core.exceptions import ObjectDoesNotExist
+from datetime import datetime, timedelta
+from django.utils.timezone import make_naive
 
 
 class ReservationService(GenericService, IReservationService):
@@ -45,9 +47,14 @@ class ReservationService(GenericService, IReservationService):
         participantes = 0
         for act in total_participantes_actuales:
             if act['idAP'] == actividad_programada.idAP:
+                fecha_fin_naive = make_naive(act['fecha_fin'])
+                print(fecha_fin_naive)
+                if fecha_fin_naive < datetime.now():
+                    raise ValueError("La actividad ya ha finalizado.") 
                 participantes = act['total_participants']
                 break
-    
+        
+
          # Verificar si la capacidad es suficiente
         if participantes + num_ninos > actividad_programada.idA.num_participantes:
             raise ValueError("La capacidad de la actividad es insuficiente para esta reservación.")

--- a/ParqueInfantil/api/DomainServices/RepositoryInterfaces/IActivityRepository.py
+++ b/ParqueInfantil/api/DomainServices/RepositoryInterfaces/IActivityRepository.py
@@ -16,3 +16,7 @@ class IActivityRepository(IGenericRepository, ABC):
     @abstractmethod
     def get_most_participated_activities(self) -> list:
         pass
+
+    @abstractmethod
+    def get_cant_participantes(self,actividad_id):
+        pass

--- a/ParqueInfantil/api/DomainServices/ServicesInterfaces/IActivityService.py
+++ b/ParqueInfantil/api/DomainServices/ServicesInterfaces/IActivityService.py
@@ -2,4 +2,17 @@ from abc import ABC, abstractmethod
 from .IGenericService import IGenericService
 
 class IActivityService(IGenericService,ABC):
-   pass
+
+
+    @abstractmethod
+    def get_cant_participantes(self,actividad_id):
+        pass
+    @abstractmethod
+    def get_most_participated_activities(self):
+         pass
+    @abstractmethod
+    def get_activities_qualifications(self):
+        pass
+    @abstractmethod
+    def get_average_calification(self, activity_id):
+         pass

--- a/ParqueInfantil/api/InfrastructurePersistence/ActivityRepository.py
+++ b/ParqueInfantil/api/InfrastructurePersistence/ActivityRepository.py
@@ -96,6 +96,9 @@ class ActivityRepository(GenericRepository, IActivityRepository):
     @staticmethod
     def get_cant_participantes(actividad_id):
         act_progs = ScheduledActRepository.get_actividades_numparticipantes()
+         # Calculate the date for one month ago from now
+        last_month = datetime.now() - timedelta(days=90)
+        act_progs = act_progs.filter(fecha_hora__gte=last_month)
         cant_participantes = 0
         for act_prog in act_progs:
             if act_prog["idA"] == actividad_id:

--- a/ParqueInfantil/api/InfrastructurePersistence/ScheduledActRepository.py
+++ b/ParqueInfantil/api/InfrastructurePersistence/ScheduledActRepository.py
@@ -54,6 +54,8 @@ class ScheduledActRepository(GenericRepository, IScheduledActRepository):
             .values('idAP')
             .annotate(idA=F('idAP__idA'))
             .annotate(nombre_actividad=F('idAP__idA__nombre'))
+            .annotate(fecha_inicio=F('idAP__fecha_hora'))
+            .annotate(fecha_fin=F('idAP__fecha_hora')+F('idAP__idA__duracion'))
             .annotate(total_participants=Sum('num_ninos'))
         )
         return actividades_participantes

--- a/ParqueInfantil/api/serializers/ActivitySerializer.py
+++ b/ParqueInfantil/api/serializers/ActivitySerializer.py
@@ -44,7 +44,7 @@ class ActividadParticipantesSerializer(serializers.ModelSerializer):
     participantes = serializers.SerializerMethodField()
 
     # def get_participantes(self, obj):
-    #     return ActivityService(ActivityRepository).get_most_participated_activities()
+    #     return ActivityService(ActivityRepository).get_cant_participantes(obj.idA)
 
     class Meta:
         model = Actividad

--- a/ParqueInfantil/api/views/activityView.py
+++ b/ParqueInfantil/api/views/activityView.py
@@ -145,6 +145,8 @@ class ActividadParticipantesView(generics.ListAPIView):
     )
     def get(self, request, *args, **kwargs):
         activities = self.activity_service.get_most_participated_activities()
+        activities = sorted(activities, key=lambda x: x["participantes"], reverse=True)
+        activities = activities[:3]
         return Response(activities, status=status.HTTP_200_OK)
 
     def get_permissions(self):


### PR DESCRIPTION
This pull request introduces several new methods and updates across multiple files to enhance the functionality of the `ParqueInfantil` application. The key changes include adding methods to retrieve participant counts for activities, adding date filtering, and updating serializers and views to use these new methods.

### New Methods and Enhancements:

* [`ParqueInfantil/api/AppServices/ActivityService.py`](diffhunk://#diff-92d10e4aec36ed71ecbb10f208b828946ec9f9433c596849198e6dbb30aeb027R53-R55): Added `get_cant_participantes` method to fetch the number of participants for a specific activity.

* [`ParqueInfantil/api/DomainServices/RepositoryInterfaces/IActivityRepository.py`](diffhunk://#diff-c23c5f1ee088e54717b6de4234da318bde746fa001b08578309016c79baf3668R19-R22): Added the abstract method `get_cant_participantes` to the `IActivityRepository` interface.

* [`ParqueInfantil/api/DomainServices/ServicesInterfaces/IActivityService.py`](diffhunk://#diff-526fa7b12f918b918d0660df5fa5efe3f5fdd6989ff6f02cd97505557b93cb68R5-R17): Added multiple abstract methods including `get_cant_participantes`, `get_most_participated_activities`, `get_activities_qualifications`, and `get_average_calification` to the `IActivityService` interface.

### Date Filtering and Validation:

* [`ParqueInfantil/api/InfrastructurePersistence/ActivityRepository.py`](diffhunk://#diff-9e23c08897b94352da5b59579b5c3ff0a138cf2f983b28be45f0cc721a6db80eR99-R101): Implemented date filtering in the `get_cant_participantes` method to only include activities from the last 90 days.

* [`ParqueInfantil/api/AppServices/ReservationService.py`](diffhunk://#diff-e7aab14f9838aa471222c2e9aad3a124f1fd33978eabb0a0763d1813ac075977R50-R57): Added date validation in the `check_for_consistency` method to ensure activities have not already ended.

### Serializer and View Updates:

* [`ParqueInfantil/api/serializers/ActivitySerializer.py`](diffhunk://#diff-b31d5986d94d2590c5b1020f90a3885622e45f4779a812e3e0da7cddf701c01bL47-R47): Updated the commented-out `get_participantes` method to use `get_cant_participantes` instead of `get_most_participated_activities`.

* [`ParqueInfantil/api/views/activityView.py`](diffhunk://#diff-ad9c2637d0263ddc9d91cef3a94a2c0e1dcafcc8efe25018c5ee5430b4682ea1R148-R149): Modified the `get` method to sort activities by participant count and limit the results to the top three activities.

These changes collectively enhance the application's ability to manage and retrieve activity data more effectively, particularly focusing on participant counts and activity durations.