### PR TITLE
feat: Update pagination settings and implement custom paginator for scheduled activities

### DIFF
--- a/ParqueInfantil/ParqueInfantil/settings.py
+++ b/ParqueInfantil/ParqueInfantil/settings.py
@@ -56,7 +56,7 @@ REST_FRAMEWORK = {
         'rest_framework.permissions.IsAuthenticated',
     ],
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
-    'PAGE_SIZE': 15,  # Número de elementos por página
+    'PAGE_SIZE': 10,  # Número de elementos por página
 }
 
 from datetime import timedelta

--- a/ParqueInfantil/api/views/SearchView.py
+++ b/ParqueInfantil/api/views/SearchView.py
@@ -56,7 +56,7 @@ class SearchView(generics.ListAPIView):
         
 
         paginator = PageNumberPagination()
-        paginator.page_size = 15  # Número de elementos por página
+        paginator.page_size = 10  # Número de elementos por página
 
         # Paginar el queryset
         result_page = paginator.paginate_queryset(results, request)

--- a/ParqueInfantil/api/views/custompaginator/custompaginator.py
+++ b/ParqueInfantil/api/views/custompaginator/custompaginator.py
@@ -1,0 +1,4 @@
+from rest_framework.pagination import PageNumberPagination
+
+class SmallPageNumberPagination(PageNumberPagination):
+    page_size = 3  # Tamaño de página específico para esta vista

--- a/ParqueInfantil/api/views/orderbyProperty.py
+++ b/ParqueInfantil/api/views/orderbyProperty.py
@@ -36,7 +36,7 @@ class OrderByPropertyView(generics.ListAPIView):
         results = repository.get_all_order_by_property(field_name, criterion)
 
         paginator = PageNumberPagination()
-        paginator.page_size = 15  # Número de elementos por página
+        paginator.page_size = 10  # Número de elementos por página
 
         # Paginar el queryset
         result_page = paginator.paginate_queryset(results, request)

--- a/ParqueInfantil/api/views/sheduledActView.py
+++ b/ParqueInfantil/api/views/sheduledActView.py
@@ -13,7 +13,7 @@ from drf_yasg.utils import swagger_auto_schema
 from drf_yasg import openapi
 from django.core.exceptions import ObjectDoesNotExist
 from rest_framework.pagination import PageNumberPagination
-
+from .custompaginator.custompaginator import SmallPageNumberPagination
 
 # vista para crear o listar todas las instalaciones
 class ScheduledActView(generics.ListCreateAPIView):
@@ -134,6 +134,7 @@ class ScheduledActRealTimeView(generics.ListAPIView):
     
 class ScheduledActCatalogView(generics.ListAPIView):
     serializer_class = ScheduledActSerializer
+    pagination_class = SmallPageNumberPagination 
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)


### PR DESCRIPTION
This pull request includes changes to the pagination settings in the `ParqueInfantil` project. The main updates involve modifying the default page size and introducing a custom pagination class for specific views.

Changes to pagination settings:

* [`ParqueInfantil/settings.py`](diffhunk://#diff-f0b3616d7fd073901ba304548f83098c06df15b6cb66d74719e446e97a30b235L59-R59): Changed the default `PAGE_SIZE` from 15 to 10.

Introduction of custom pagination:

* [`ParqueInfantil/api/views/custompaginator/custompaginator.py`](diffhunk://#diff-4c583a96dadf1cb40762ec2e7098c61cf51472e7e73eee4e84c9ce7c8f4d06d7R1-R4): Added a new `SmallPageNumberPagination` class with a `page_size` of 3.
* [`ParqueInfantil/api/views/sheduledActView.py`](diffhunk://#diff-d911fa8eaac2195e7f00c08c60d685b2e9680c0b1003d5702adbc511ad77752aL16-R16): Imported the new `SmallPageNumberPagination` class and applied it to the `ScheduledActCatalogView` by setting its `pagination_class`. [[1]](diffhunk://#diff-d911fa8eaac2195e7f00c08c60d685b2e9680c0b1003d5702adbc511ad77752aL16-R16) [[2]](diffhunk://#diff-d911fa8eaac2195e7f00c08c60d685b2e9680c0b1003d5702adbc511ad77752aR137)